### PR TITLE
FIX menu closing on IOS device

### DIFF
--- a/quartz/components/styles/explorer-burger.scss
+++ b/quartz/components/styles/explorer-burger.scss
@@ -48,7 +48,6 @@
   #explorer-content {
     width: 90vw;
     background-color: var(--light);
-    height: 100vh;
     position: absolute;
     z-index: 100;
     max-height: max-content !important;
@@ -79,15 +78,6 @@
         stroke: var(--dark);
       }
     }
-  }
-}
-
-@keyframes fadeOut {
-  0% {
-    opacity: 1;
-  }
-  100% {
-    opacity: 0;
   }
 }
 

--- a/quartz/components/styles/explorer-burger.scss
+++ b/quartz/components/styles/explorer-burger.scss
@@ -46,36 +46,14 @@
 
 .mobile-only.explorer {
   #explorer-content {
-    &:not(.collapsed) {
-      width: 90vw;
-      background-color: var(--light);
-      height: 100vh;
-      position: absolute;
-      z-index: 100;
-      max-height: max-content !important;
-      //transition: all 500ms;
-      overflow: hidden;
-      //blur the background
-      //top: 10dvh;
-      filter: blur(0);
-      transition: all 500ms;
-    }
-
-    &.collapsed li {
-      filter: blur(150px);
-      //transition: all 500ms;
-      //transition: all 500ms;
-    }
-
-    &:not(.collapsed) li {
-      filter: blur(0);
-      //transition: all 500ms;
-      //transition: all 500ms;
-    }
-
-    /* ul.overflow {
-      max-height: 70dvh;
-    } */
+    width: 90vw;
+    background-color: var(--light);
+    height: 100vh;
+    position: absolute;
+    z-index: 100;
+    max-height: max-content !important;
+    transition: all 500ms ease;
+    overflow: hidden;
 
     &.collapsed {
       left: 0;
@@ -83,10 +61,9 @@
       background-color: var(--light);
       height: 100dvh;
       position: absolute;
-      max-height: max-content !important;
       z-index: 100;
       filter: blur(150px);
-      transition: all 500ms linear;
+      transition: all 250ms ease-out;
     }
   }
 
@@ -102,6 +79,15 @@
         stroke: var(--dark);
       }
     }
+  }
+}
+
+@keyframes fadeOut {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
   }
 }
 


### PR DESCRIPTION
For an unknown reason, the blur was creating a bug on IOS that leaded into 3 seconds to close
   `&.collapsed li {
      filter: blur(150px);
      //transition: all 500ms;
      //transition: all 500ms;
    }`
